### PR TITLE
Add "profile." prefix to default profile.

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,4 +1,4 @@
-[default]
+[profile.default]
 src = 'src'
 out = 'out'
 libs = ['lib']


### PR DESCRIPTION
By recommendation of forge's CLI.

> This notation for profiles has been deprecated and may result in the profile not being registered in 
> future versions. Please use [profile.default] instead [..]